### PR TITLE
Bump til Spring Boot 3.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.2.5"
+    id("org.springframework.boot") version "3.3.1"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     kotlin("jvm") version "1.9.24"
@@ -24,7 +24,7 @@ repositories {
 }
 
 val testContainersVersion = "1.20.0"
-val tokenSupportVersion = "4.1.7"
+val tokenSupportVersion = "5.0.1"
 val logstashLogbackEncoderVersion = "7.4"
 val kluentVersion = "1.73"
 val inntektsmeldingKontraktVersion = "2024.05.21-09-56-5528e"
@@ -41,7 +41,7 @@ dependencies {
     implementation("org.hibernate.validator:hibernate-validator")
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.postgresql:postgresql")
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashLogbackEncoderVersion")
     implementation("no.nav.security:token-validation-spring:$tokenSupportVersion")

--- a/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
@@ -52,7 +52,7 @@ abstract class FellesTestOppsett {
             val threads = mutableListOf<Thread>()
 
             thread {
-                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3")).apply {
+                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).apply {
                     start()
                     System.setProperty("KAFKA_BROKERS", bootstrapServers)
                 }


### PR DESCRIPTION
    org.springframework.boot from 3.2.5 to 3.3.1
    tokenSupportVersion from 4.1.7 to 5.0.1
    io.spring.dependency-management from 1.1.5 to 1.1.6
    cp-kafka to 7.6.1
    Byttet fra flyway-core til flyway-database-postgresql
