### PR TITLE
Oppgraderer spring boot til versjon 3.5.13

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.5.12"
+    id("org.springframework.boot") version "3.5.13"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     kotlin("jvm") version "2.3.20"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,9 @@ val logstashLogbackEncoderVersion = "9.0"
 val kluentVersion = "1.73"
 val inntektsmeldingKontraktVersion = "2025.04.04-01-56-365d3"
 val sykepengesoknadKafkaVersion = "2025.11.18-06.24-f860ace9"
+val jacksonVersion = "2.20.2"
+
+extra["jackson.version"] = jacksonVersion
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ spring:
     hikari:
       minimum-idle: 1
       maximum-pool-size: 5
+  jackson:
+    mapper:
+      fix-field-name-upper-case-prefix: false
 
 aiven-kafka:
   auto-offset-reset: none


### PR DESCRIPTION
Oppgraderer spring boot til versjon 3.5.13 for å fikse CVE-2026-29145. Må også pinne jackson versjon med ekstra config for å støtte deserialisering av inntektsmeldinger